### PR TITLE
Enable usage without Ember Data.

### DIFF
--- a/addon/controllers/delete.js
+++ b/addon/controllers/delete.js
@@ -1,3 +1,4 @@
+import { singularize } from '../inflector';
 import BaseController from './base';
 
 export default BaseController.extend({
@@ -13,7 +14,7 @@ export default BaseController.extend({
     var id = request.params.id;
     var url = request.url;
     var urlNoId = id ? url.substr(0, url.lastIndexOf('/')) : url;
-    var type = urlNoId.substr(urlNoId.lastIndexOf('/') + 1).singularize();
+    var type = singularize(urlNoId.substr(urlNoId.lastIndexOf('/') + 1));
 
     var data = store.remove(type, +id);
 

--- a/addon/controllers/get.js
+++ b/addon/controllers/get.js
@@ -1,3 +1,4 @@
+import { singularize } from '../inflector';
 import BaseController from './base';
 
 /*
@@ -15,7 +16,7 @@ export default BaseController.extend({
     var data = {};
 
     // TODO: This is a crass way of checking if we're looking for a single model, doens't work for e.g. sheep
-    if (key.singularize() === key) {
+    if (singularize(key) === key) {
       var id = request.params.id;
       if (!id) { console.error("Pretenderify: You're trying to find a model by id, but no :id param was found in this route's URL."); return;}
       var model = store.find(key, request.params.id);
@@ -48,7 +49,7 @@ export default BaseController.extend({
 
       // There's an owner. Find only related.
       if (ownerKey) {
-        var ownerIdKey = ownerKey.singularize() + '_id';
+        var ownerIdKey = singularize(ownerKey) + '_id';
         var query = {};
         query[ownerIdKey] = owner.id;
         data[key] = store.find(key, query);
@@ -56,7 +57,7 @@ export default BaseController.extend({
       } else {
 
         // TODO: This is a crass way of checking if we're looking for a single model, doens't work for e.g. sheep
-        if (key.singularize() === key) {
+        if (singularize(key) === key) {
           ownerKey = key;
           var model = store.find(key, request.params.id);
           data[key] = model;
@@ -85,7 +86,7 @@ export default BaseController.extend({
     var id = request.params.id;
     var url = request.url;
     var urlNoId = id ? url.substr(0, url.lastIndexOf('/')) : url;
-    var type = urlNoId.substr(urlNoId.lastIndexOf('/') + 1).singularize();
+    var type = singularize(urlNoId.substr(urlNoId.lastIndexOf('/') + 1));
     var data = {};
 
     data[type] = id ? store.find(type, id) : store.findAll(type);

--- a/addon/controllers/post.js
+++ b/addon/controllers/post.js
@@ -1,3 +1,4 @@
+import { singularize } from '../inflector';
 import BaseController from './base';
 
 /*
@@ -28,7 +29,7 @@ export default BaseController.extend({
   */
   undefinedHandler: function(undef, store, request, code) {
     var url = request.url;
-    var type = url.substr(url.lastIndexOf('/') + 1).singularize();
+    var type = singularize(url.substr(url.lastIndexOf('/') + 1));
     var postData = JSON.parse(request.requestBody);
     var attrs = postData[type];
     var data = store.push(type, attrs);

--- a/addon/controllers/put.js
+++ b/addon/controllers/put.js
@@ -1,3 +1,4 @@
+import { singularize } from '../inflector';
 import BaseController from './base';
 
 export default BaseController.extend({
@@ -12,7 +13,7 @@ export default BaseController.extend({
     var id = request.params.id;
     var url = request.url;
     var urlNoId = url.substr(0, url.lastIndexOf('/'));
-    var type = urlNoId.substr(urlNoId.lastIndexOf('/') + 1).singularize();
+    var type = singularize(urlNoId.substr(urlNoId.lastIndexOf('/') + 1));
     var modelData = JSON.parse(request.requestBody);
     var attrs = modelData[type];
     attrs.id = +id;

--- a/addon/inflector.js
+++ b/addon/inflector.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export var singularize = Ember.String.singularize;
+export var pluralize = Ember.String.pluralize;

--- a/addon/store.js
+++ b/addon/store.js
@@ -1,3 +1,4 @@
+import { pluralize } from './inflector';
 /*
   An identity map.
 */
@@ -18,7 +19,7 @@ export default {
   },
 
   find: function(key, id) {
-    key = key.pluralize();
+    key = pluralize(key);
     var data;
     var query;
 
@@ -105,7 +106,7 @@ export default {
 
   remove: function(key, id) {
     var _this = this;
-    var dataKey = key.pluralize();
+    var dataKey = pluralize(key);
 
     this._data[dataKey] = this._data[dataKey].rejectBy('id', +id);
     return {};

--- a/blueprints/ember-pretenderify/index.js
+++ b/blueprints/ember-pretenderify/index.js
@@ -9,5 +9,6 @@ module.exports = {
 
   afterInstall: function() {
     return this.addBowerPackageToProject('pretender', '~0.6.0');
+    return this.addBowerPackageToProject('ember-inflector', '~1.4.0');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.5",
     "qunit": "~1.17.1",
-    "pretender": "~0.6.0"
+    "pretender": "~0.6.0",
+    "ember-inflector": "~1.3.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
       type: 'vendor',
       exports: { 'pretender': ['default'] }
     });
+    app.import(app.bowerDirectory + '/ember-inflector/ember-inflector.js');
   },
 
   blueprintsPath: function() {

--- a/tests/unit/inflector-test.js
+++ b/tests/unit/inflector-test.js
@@ -1,0 +1,15 @@
+import { singularize, pluralize } from 'ember-pretenderify/inflector';
+
+QUnit.module('pretenderify:inflector');
+
+QUnit.test('can singularize', function(assert) {
+  assert.equal(singularize('tests'), 'test');
+  assert.equal(singularize('watches'), 'watch');
+  assert.equal(singularize('sheep'), 'sheep');
+});
+
+QUnit.test('can pluralize', function(assert) {
+  assert.equal(pluralize('test'), 'tests');
+  assert.equal(pluralize('watch'), 'watches');
+  assert.equal(pluralize('sheep'), 'sheep');
+});


### PR DESCRIPTION
`ember-inflector` is used by Ember Data, but we should pull it in
manually so that it does work without Ember Data.