### PR TITLE
Don't include files in production build

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,17 +7,32 @@ module.exports = {
   included: function included(app) {
     this.app = app;
 
-    app.import(app.bowerDirectory + '/FakeXMLHttpRequest/fake_xml_http_request.js');
-    app.import(app.bowerDirectory + '/route-recognizer/dist/route-recognizer.js');
-    app.import(app.bowerDirectory + '/pretender/pretender.js');
-    app.import('vendor/ember-pretenderify/shim.js', {
-      type: 'vendor',
-      exports: { 'pretender': ['default'] }
-    });
-    app.import(app.bowerDirectory + '/ember-inflector/ember-inflector.js');
+    if (this.shouldIncludeFiles()) {
+      app.import(app.bowerDirectory + '/FakeXMLHttpRequest/fake_xml_http_request.js');
+      app.import(app.bowerDirectory + '/route-recognizer/dist/route-recognizer.js');
+      app.import(app.bowerDirectory + '/pretender/pretender.js');
+      app.import('vendor/ember-pretenderify/shim.js', {
+        type: 'vendor',
+        exports: { 'pretender': ['default'] }
+      });
+      app.import(app.bowerDirectory + '/ember-inflector/ember-inflector.js');
+    }
   },
 
   blueprintsPath: function() {
     return path.join(__dirname, 'blueprints');
   },
+
+  treeFor: function(name) {
+    if (this.shouldIncludeFiles()) {
+      return this._super.treeFor.apply(this, arguments);
+    }
+    this._requireBuildPackages();
+    return this.mergeTrees([]);
+  },
+
+  shouldIncludeFiles: function() {
+    var config = this.app.project.config()['ember-pretenderify'];
+    return config.force || this.app.env !== 'production';
+  }
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test"
+    "test": "ember test && mocha tests/**/*-test-node.js"
   },
   "repository": {
     "type": "git",
@@ -29,6 +29,7 @@
     "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "broccoli-static-compiler": "^0.2.1",
+    "chai": "^2.0.0",
     "ember-cli": "0.1.9",
     "ember-cli-6to5": "0.2.1",
     "ember-cli-content-security-policy": "0.3.0",
@@ -38,9 +39,10 @@
     "ember-cli-qunit": "0.1.2",
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
+    "es5-shim": "^4.0.6",
     "express": "^4.8.5",
     "glob": "^4.0.5",
-    "es5-shim": "^4.0.6"
+    "mocha": "^2.1.0"
   },
   "keywords": [
     "ember-addon",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -45,7 +45,11 @@
     "currentURL",
     "currentPath",
     "currentRouteName",
-    "store"
+    "store",
+    "require",
+    "describe",
+    "afterEach",
+    "it"
   ],
   "node": false,
   "browser": false,

--- a/tests/fixtures/config/environment-with-force-true.js
+++ b/tests/fixtures/config/environment-with-force-true.js
@@ -1,0 +1,50 @@
+/* jshint node: true */
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'scaffold-test',
+    environment: environment,
+    baseURL: '/',
+    locationType: 'auto',
+    EmberENV: {
+      FEATURES: {
+        // Here you can enable experimental features on an ember canary build
+        // e.g. 'with-controller': true
+      }
+    },
+
+    APP: {
+      // Here you can pass flags/options to your application instance
+      // when it is created
+    },
+    'ember-pretenderify': {
+      force: true
+    }
+  };
+
+  if (environment === 'development') {
+    // ENV.APP.LOG_RESOLVER = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_TRANSITIONS = true;
+    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+  }
+
+  if (environment === 'test') {
+    // Testem prefers this...
+    ENV.baseURL = '/';
+    ENV.locationType = 'none';
+
+    // keep test console output quieter
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.APP.rootElement = '#ember-testing';
+  }
+
+  if (environment === 'production') {
+
+  }
+
+  return ENV;
+};

--- a/tests/unit/addon-tree-test-node.js
+++ b/tests/unit/addon-tree-test-node.js
@@ -1,0 +1,46 @@
+ /*jshint -W079 */
+var expect = require('chai').expect;
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+var path = require('path');
+
+describe('treeFor', function() {
+  afterEach(function() {
+    delete process.env.EMBER_ENV;
+  });
+
+  function getPretenderifyAddon(options) {
+    var addon = new EmberAddon(options);
+    var addons = addon.project.addons;
+    for(var i = 0; i < addons.length; i++) {
+      if(addons[i].name === 'ember-pretenderify') {
+        return addons[i];
+      }
+    }
+  }
+
+  it('returns an empty tree in production environment', function() {
+    process.env.EMBER_ENV = 'production';
+    var addonTree = getPretenderifyAddon().treeFor('addon');
+
+    expect(addonTree.inputTrees.length).to.be.equal(0);
+  });
+
+  ['development', 'test'].forEach(function(environment) {
+
+    it('returns a tree in ' + environment + ' environment', function() {
+      process.env.EMBER_ENV = environment;
+      var addonTree = getPretenderifyAddon().treeFor('addon');
+
+      expect(addonTree.inputTrees.length).to.be.equal(1);
+    });
+
+  });
+
+  it('returns a tree regardless the environment when force option is true', function() {
+    process.env.EMBER_ENV = 'production';
+    var addon = getPretenderifyAddon({ configPath: 'tests/fixtures/config/environment-with-force-true' });
+    var addonTree = addon.treeFor('addon');
+
+    expect(addonTree.inputTrees.length).to.be.equal(1);
+  });
+});

--- a/tests/unit/import-files-test-node.js
+++ b/tests/unit/import-files-test-node.js
@@ -1,0 +1,52 @@
+ /*jshint -W079 */
+var expect = require('chai').expect;
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+
+describe('import files', function() {
+  afterEach(function() {
+    delete process.env.EMBER_ENV;
+  });
+
+  ['development', 'test'].forEach(function(environment) {
+
+    it('includes third party libraries in ' + environment + ' environment', function() {
+      process.env.EMBER_ENV = environment;
+      var addon = new EmberAddon();
+
+      expect(addon.legacyFilesToAppend).to.include.members([
+        addon.bowerDirectory + '/FakeXMLHttpRequest/fake_xml_http_request.js',
+        addon.bowerDirectory + '/route-recognizer/dist/route-recognizer.js',
+        addon.bowerDirectory + '/pretender/pretender.js',
+        'vendor/ember-pretenderify/shim.js',
+        addon.bowerDirectory + '/ember-inflector/ember-inflector.js'
+      ]);
+    });
+
+  });
+
+  it('doesn\'t include third party libraries in production environment', function() {
+    process.env.EMBER_ENV = 'production';
+    var addon = new EmberAddon();
+
+    expect(addon.legacyFilesToAppend).to.not.include.members([
+      addon.bowerDirectory + '/FakeXMLHttpRequest/fake_xml_http_request.js',
+      addon.bowerDirectory + '/route-recognizer/dist/route-recognizer.js',
+      addon.bowerDirectory + '/pretender/pretender.js',
+      'vendor/ember-pretenderify/shim.js',
+      addon.bowerDirectory + '/ember-inflector/ember-inflector.js'
+    ]);
+  });
+
+  it('includes third party libraries regardless the environment when force option is true', function() {
+    process.env.EMBER_ENV = 'production';
+    var addon = new EmberAddon({ configPath: 'tests/fixtures/config/environment-with-force-true' });
+
+    expect(addon.legacyFilesToAppend).to.include.members([
+      addon.bowerDirectory + '/FakeXMLHttpRequest/fake_xml_http_request.js',
+      addon.bowerDirectory + '/route-recognizer/dist/route-recognizer.js',
+      addon.bowerDirectory + '/pretender/pretender.js',
+      'vendor/ember-pretenderify/shim.js',
+      addon.bowerDirectory + '/ember-inflector/ember-inflector.js'
+    ]);
+  });
+});


### PR DESCRIPTION
In order to test this behaviour I added some files ending with `*test-node.js` which will be tested in the node context using mocha. I tried to not touch so much the ember-cli internals, since testing these file inclusions isn't so clear, but if something changes in the next ember-cli versions, the tests will point out.

//cc @samselikoff 

Fixes #17 