### PR TITLE
Remove app/pretender dir in production builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,5 +34,20 @@ module.exports = {
   shouldIncludeFiles: function() {
     var config = this.app.project.config()['ember-pretenderify'];
     return config.force || this.app.env !== 'production';
+  },
+
+  postprocessTree: function(type, tree) {
+    if(type === 'js' && !this.shouldIncludeFiles()) {
+      return this.excludePretenderDir(tree);
+    }
+    return tree;
+  },
+
+  excludePretenderDir: function(tree) {
+    var modulePrefix = this.app.project.config()['modulePrefix'];
+    return new this.Funnel(tree, {
+      exclude: [new RegExp('^' + modulePrefix + '/pretender/')],
+      description: 'Funnel: exclude pretender'
+    });
   }
 };

--- a/tests/unit/addon-tree-test-node.js
+++ b/tests/unit/addon-tree-test-node.js
@@ -3,44 +3,104 @@ var expect = require('chai').expect;
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 var path = require('path');
 
-describe('treeFor', function() {
+function getPretenderifyAddon(options) {
+  var dummyApp = new EmberAddon(options);
+  return findPretenderify(dummyApp);
+}
+
+function findPretenderify(app) {
+  var addons = app.project.addons;
+  for(var i = 0; i < addons.length; i++) {
+    if(addons[i].name === 'ember-pretenderify') {
+      return addons[i];
+    }
+  }
+}
+
+describe('Addon', function() {
   afterEach(function() {
     delete process.env.EMBER_ENV;
   });
 
-  function getPretenderifyAddon(options) {
-    var addon = new EmberAddon(options);
-    var addons = addon.project.addons;
-    for(var i = 0; i < addons.length; i++) {
-      if(addons[i].name === 'ember-pretenderify') {
-        return addons[i];
-      }
-    }
-  }
+  describe('#treeFor', function() {
 
-  it('returns an empty tree in production environment', function() {
-    process.env.EMBER_ENV = 'production';
-    var addonTree = getPretenderifyAddon().treeFor('addon');
-
-    expect(addonTree.inputTrees.length).to.be.equal(0);
-  });
-
-  ['development', 'test'].forEach(function(environment) {
-
-    it('returns a tree in ' + environment + ' environment', function() {
-      process.env.EMBER_ENV = environment;
+    it('returns an empty tree in production environment', function() {
+      process.env.EMBER_ENV = 'production';
       var addonTree = getPretenderifyAddon().treeFor('addon');
+
+      expect(addonTree.inputTrees.length).to.be.equal(0);
+    });
+
+    ['development', 'test'].forEach(function(environment) {
+
+      it('returns a tree in ' + environment + ' environment', function() {
+        process.env.EMBER_ENV = environment;
+        var addonTree = getPretenderifyAddon().treeFor('addon');
+
+        expect(addonTree.inputTrees.length).to.be.equal(1);
+      });
+
+    });
+
+    it('returns a tree regardless the environment when force option is true', function() {
+      process.env.EMBER_ENV = 'production';
+      var addon = getPretenderifyAddon({ configPath: 'tests/fixtures/config/environment-with-force-true' });
+      var addonTree = addon.treeFor('addon');
 
       expect(addonTree.inputTrees.length).to.be.equal(1);
     });
 
   });
 
-  it('returns a tree regardless the environment when force option is true', function() {
-    process.env.EMBER_ENV = 'production';
-    var addon = getPretenderifyAddon({ configPath: 'tests/fixtures/config/environment-with-force-true' });
-    var addonTree = addon.treeFor('addon');
+  describe('#postprocessTree', function() {
 
-    expect(addonTree.inputTrees.length).to.be.equal(1);
+    it('excludes app/pretender tree in production environment', function() {
+      this.timeout(10000);
+      process.env.EMBER_ENV = 'production';
+      var excludePretenderDirCalled = false;
+      var dummyApp = new EmberAddon();
+      var addon = findPretenderify(dummyApp);
+      addon.excludePretenderDir = function(tree) {
+        excludePretenderDirCalled = true;
+        return tree;
+      };
+      dummyApp.toTree();
+
+      expect(excludePretenderDirCalled).to.be.equal(true);
+    });
+
+    ['development', 'test'].forEach(function(environment) {
+
+      it('includes app/pretender tree in ' + environment + ' environment', function() {
+        this.timeout(10000);
+        process.env.EMBER_ENV = environment;
+        var excludePretenderDirCalled = false;
+        var dummyApp = new EmberAddon();
+        var addon = findPretenderify(dummyApp);
+        addon.excludePretenderDir = function(tree) {
+          excludePretenderDirCalled = true;
+          return tree;
+        };
+        dummyApp.toTree();
+
+        expect(excludePretenderDirCalled).to.be.equal(false);
+      });
+
+    });
+
+    it('includes app/pretender tree regardless the environment when force option is true', function() {
+      this.timeout(10000);
+      process.env.EMBER_ENV = 'production';
+      var excludePretenderDirCalled = false;
+      var dummyApp = new EmberAddon({ configPath: 'tests/fixtures/config/environment-with-force-true' });
+      var addon = findPretenderify(dummyApp);
+      addon.excludePretenderDir = function(tree) {
+        excludePretenderDirCalled = true;
+        return tree;
+      };
+      dummyApp.toTree();
+
+      expect(excludePretenderDirCalled).to.be.equal(false);
+    });
   });
 });


### PR DESCRIPTION
By default ember-cli includes anything found in [`app/*`](https://github.com/ember-cli/ember-cli/blob/master/lib/broccoli/ember-app.js#L206) dir like `app/pretender`. To get around this we can remove the `app/pretender` from the app tree using broccoli-funnel when it's not needed.

Fixes #17